### PR TITLE
Shared read and shared write mode is needed

### DIFF
--- a/hid_windows.go
+++ b/hid_windows.go
@@ -103,12 +103,11 @@ func getCString(fnCall callCFn) string {
 
 func openDevice(info *DeviceInfo, enumerate bool) (*winDevice, error) {
 	access := uint32(syscall.GENERIC_WRITE | syscall.GENERIC_READ)
-	shareMode := uint32(syscall.FILE_SHARE_READ)
+	shareMode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE)
 	if enumerate {
 		// if we just need a handle to get the device properties
 		// we should not claim exclusive access on the device
 		access = 0
-		shareMode = uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE)
 	}
 	pPtr, err := syscall.UTF16PtrFromString(info.Path)
 	if err != nil {


### PR DESCRIPTION
On later Windows versions access to HID devices is denied if shared write is not present. This change uses shared read and write for enumeration and regular operation.